### PR TITLE
34 ajustar dockerfile para uso de redes y cambios a galeria

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ networks:
   default:
     name: nginx-proxy
   app-network:
-    driver: bridge
+    external: true
 volumes:
   dbdata:
     driver: local

--- a/resources/js/Pages/Pictures/IndexPicture.tsx
+++ b/resources/js/Pages/Pictures/IndexPicture.tsx
@@ -110,9 +110,13 @@ export default function IndexPicture({
             {
                 selectedPicture &&
                 (<Dialog open={abrirModal} onOpenChange={setAbrirModal}>
-                    <DialogContent className='max-w-7xl'>
-                        <div className='flex items-center justify-center'>
-                            <img src={route('picture.show', selectedPicture.id)} alt="" />
+                    <DialogContent className="max-w-7xl max-h-full flex items-center justify-center">
+                        <div className="max-w-full max-h-[80vh] overflow-auto flex items-center justify-center">
+                            <img 
+                                src={route('picture.show', selectedPicture.id)} 
+                                className="max-w-full max-h-full object-contain" 
+                                alt="" 
+                            />
                         </div>
                     </DialogContent>
                 </Dialog>)


### PR DESCRIPTION
Se acomodó el docker file para poder permitir la conexión con la api de flask, así mismo se ajustó el tamaño del modal para las imágenes muy grandes